### PR TITLE
Con 5371 fix

### DIFF
--- a/NoMAD-ADAuth.xcodeproj/project.pbxproj
+++ b/NoMAD-ADAuth.xcodeproj/project.pbxproj
@@ -523,7 +523,7 @@
 					"$(inherited)",
 					"$(SDKROOT)/usr/lib/system",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 13.5;
 				MARKETING_VERSION = 1.0.5;
 				MODULEMAP_PRIVATE_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "menu.nomad.NoMAD-ADAuth";
@@ -556,7 +556,7 @@
 					"$(inherited)",
 					"$(SDKROOT)/usr/lib/system",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				MACOSX_DEPLOYMENT_TARGET = 13.5;
 				MARKETING_VERSION = 1.0.5;
 				MODULEMAP_PRIVATE_FILE = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "menu.nomad.NoMAD-ADAuth";

--- a/NoMAD-ADAuth/Logger.swift
+++ b/NoMAD-ADAuth/Logger.swift
@@ -34,12 +34,8 @@ enum LogLevel: Int {
     case debug = 3
 }
 
-var log: OSLog? {
-    if #available(OSX 10.12, *) {
-        return OSLog(subsystem: "menu.nomad.login.ad", category: "framework")
-    } else {
-        return nil
-    }
+var log: OSLog {
+    OSLog(subsystem: "menu.nomad.login.ad", category: "framework")
 }
 
 
@@ -70,11 +66,7 @@ class Logger {
     ///   - message: A `String` that describes the information to be logged
     func logit(_ level: LogLevel, message: String) {
         if (level.rawValue <= loglevel.rawValue) {
-            if #available(OSX 10.12, *) {
-                os_log("%{public}@", log: log!, type: .debug, message)
-            } else {
-                NSLog("level: \(level) - " + message)
-            }
+            os_log("%{public}@", log: log, type: .debug, message)
         }
     }
 }

--- a/NoMAD-ADAuth/NoMADSession.swift
+++ b/NoMAD-ADAuth/NoMADSession.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import os.log
 import NoMADPRIVATE
 
 public protocol NoMADUserSession {
@@ -659,8 +660,8 @@ public class NoMADSession: NSObject {
                     customAttributeResults = tempCustomAttr
                 }
                 
-                if ldapResult.count == 0 {
-                    // we didn't get a result
+                if ldapResult.isEmpty {
+                    os.Logger(log).error("no result for LDAP user search: \(attributes.joined(separator: " "), privacy: .public)")
                 }
                 
                 lookupRecursiveGroups(dn, &groupsTemp)

--- a/NoMAD-ADAuth/NoMADSession.swift
+++ b/NoMAD-ADAuth/NoMADSession.swift
@@ -538,10 +538,10 @@ public class NoMADSession: NSObject {
         }
     }
 
-    fileprivate func parseExpirationDate(_ computedExpireDateRaw: String?, _ passwordAging: inout Bool, _ userPasswordExpireDate: inout Date, _ userPasswordUACFlag: String, _ serverPasswordExpirationDefault: inout Double, _ tempPasswordSetDate: Date) {
-        if computedExpireDateRaw != nil {
+    fileprivate func parseExpirationDate(_ computedExpireDateRaw: String?, _ passwordAging: inout Bool, _ userPasswordExpireDate: inout Date?, _ userPasswordUACFlag: String, _ serverPasswordExpirationDefault: inout Double, _ tempPasswordSetDate: Date) {
+        if let computedExpireDateRaw {
             // Windows Server 2008 and Newer
-            if Int(computedExpireDateRaw!) ==  Int.max {
+            if Int(computedExpireDateRaw) ==  Int.max {
 
                 // Password doesn't expire
                 passwordAging = false
@@ -549,7 +549,7 @@ public class NoMADSession: NSObject {
                 // Set expiration to far away from now
                 userPasswordExpireDate = Date.distantFuture
 
-            } else if (Int(computedExpireDateRaw!) == 0) {
+            } else if (Int(computedExpireDateRaw) == 0) {
 
                 // password needs to be reset
                 passwordAging = true
@@ -560,7 +560,7 @@ public class NoMADSession: NSObject {
             } else {
                 // Password expires
                 passwordAging = true
-                userPasswordExpireDate = NSDate(timeIntervalSince1970: (Double(computedExpireDateRaw!)!)/10000000-11644473600) as Date
+                userPasswordExpireDate = NSDate(timeIntervalSince1970: (Double(computedExpireDateRaw)!)/10000000-11644473600) as Date
             }
         } else {
             // Older then Windows Server 2008
@@ -573,11 +573,18 @@ public class NoMADSession: NSObject {
             } else {
                 passwordExpirationLength = ""
             }
+            
+            // -9223372036854775808 is never
+            guard passwordExpirationLength != "-9223372036854775808" else {
+                // we could end up here if the value for sAMAccountName is not correct
+                // in which case we can't really determine the expiration if one exists
+                return
+            }
 
-            if ( passwordExpirationLength.count > 15 ) {
+            if passwordExpirationLength.count > 15 {
                 passwordAging = false
-            } else if ( passwordExpirationLength != "" ) && userPasswordUACFlag != "" {
-                if ~~( Int(userPasswordUACFlag)! & 0x10000 ) {
+            } else if passwordExpirationLength != "", userPasswordUACFlag != "" {
+                if ~~(Int(userPasswordUACFlag)! & 0x10000) {
                     passwordAging = false
                 } else {
                     serverPasswordExpirationDefault = Double(abs(Int(passwordExpirationLength)!)/10000000)
@@ -587,6 +594,7 @@ public class NoMADSession: NSObject {
                 serverPasswordExpirationDefault = Double(0)
                 passwordAging = false
             }
+            
             userPasswordExpireDate = tempPasswordSetDate.addingTimeInterval(serverPasswordExpirationDefault)
         }
     }
@@ -611,7 +619,7 @@ public class NoMADSession: NSObject {
         var passwordAging = true
         var tempPasswordSetDate = Date()
         var serverPasswordExpirationDefault = 0.0
-        var userPasswordExpireDate = Date()
+        var userPasswordExpireDate: Date?
         var groups = [String]()
         var userHome = ""
         
@@ -657,9 +665,10 @@ public class NoMADSession: NSObject {
                 
                 lookupRecursiveGroups(dn, &groupsTemp)
                 
-                if (passwordSetDate != "") && (passwordSetDate != nil ) {
-                    tempPasswordSetDate = NSDate(timeIntervalSince1970: (Double(passwordSetDate!)!)/10000000-11644473600) as Date
+                if let passwordSetDate, !passwordSetDate.isEmpty {
+                    tempPasswordSetDate = NSDate(timeIntervalSince1970: (Double(passwordSetDate)!)/10000000-11644473600) as Date
                 }
+                
                 parseExpirationDate(computedExpireDateRaw, &passwordAging, &userPasswordExpireDate, userPasswordUACFlag, &serverPasswordExpirationDefault, tempPasswordSetDate)
                 
                 cleanGroups(groupsTemp, &groups)

--- a/NoMAD-ADAuth/UNIXUtilities.swift
+++ b/NoMAD-ADAuth/UNIXUtilities.swift
@@ -68,8 +68,6 @@ public func cliTask(_ command: String, arguments: [String]? = nil, waitForTermin
     myTask.standardOutput = outputPipe
     myTask.standardInput = myInputPipe
     myTask.standardError = myErrorPipe
-    
-    os.Logger().debug("💻 - \(commandLaunchPath) \(commandPieces)")
 
     myTask.launch()
     
@@ -92,7 +90,7 @@ public func cliTask(_ command: String, arguments: [String]? = nil, waitForTermin
     let error = myErrorPipe.fileHandleForReading.readDataToEndOfFile()
     let outputError = NSString(data: error, encoding: String.Encoding.utf8.rawValue)! as String
     
-    os.Logger().debug("🏁\n\(outputString + outputError)")
+    os.Logger().debug("💻 \(commandLaunchPath) \(commandPieces.joined(separator: " "))\n🏁\n\(outputString + outputError)")
     
     return outputString + outputError
 }

--- a/NoMAD-ADAuth/UNIXUtilities.swift
+++ b/NoMAD-ADAuth/UNIXUtilities.swift
@@ -90,7 +90,8 @@ public func cliTask(_ command: String, arguments: [String]? = nil, waitForTermin
     let error = myErrorPipe.fileHandleForReading.readDataToEndOfFile()
     let outputError = NSString(data: error, encoding: String.Encoding.utf8.rawValue)! as String
     
-    os.Logger().debug("💻 \(commandLaunchPath) \(commandPieces.joined(separator: " "))\n🏁\n\(outputString + outputError)")
+    // should keep this values private just in case, this statement is useful to understand how menubar is using this code
+    os.Logger(log).debug("💻 \(commandLaunchPath) \(commandPieces.joined(separator: " "))\n🏁\n\(outputString + outputError)")
     
     return outputString + outputError
 }

--- a/NoMAD-ADAuth/UNIXUtilities.swift
+++ b/NoMAD-ADAuth/UNIXUtilities.swift
@@ -10,6 +10,7 @@
 import Foundation
 import SystemConfiguration
 import IOKit
+import os
 
 
 /// A simple wrapper around NSTask
@@ -20,7 +21,6 @@ import IOKit
 ///   - waitForTermination: An optional `Bool` Should the the output be delayed until the task exits. Deafults to 'true'.
 /// - Returns: The combined result of standard output and standard error from the command.
 public func cliTask(_ command: String, arguments: [String]? = nil, waitForTermination: Bool = true) -> String {
-
     var commandLaunchPath: String
     var commandPieces: [String]
     
@@ -68,6 +68,8 @@ public func cliTask(_ command: String, arguments: [String]? = nil, waitForTermin
     myTask.standardOutput = outputPipe
     myTask.standardInput = myInputPipe
     myTask.standardError = myErrorPipe
+    
+    os.Logger().debug("💻 - \(commandLaunchPath) \(commandPieces)")
 
     myTask.launch()
     
@@ -89,6 +91,8 @@ public func cliTask(_ command: String, arguments: [String]? = nil, waitForTermin
 
     let error = myErrorPipe.fileHandleForReading.readDataToEndOfFile()
     let outputError = NSString(data: error, encoding: String.Encoding.utf8.rawValue)! as String
+    
+    os.Logger().debug("🏁\n\(outputString + outputError)")
     
     return outputString + outputError
 }


### PR DESCRIPTION
If no LDAP user info is available we will no longer default to the current date and instead return `nil` because we don't have any information about the password expiration. Typically this happens when the kerberos short name is not correctly configured.